### PR TITLE
Change SCAPY source

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #/bin/sh
 
-SCAPY=http://bb.secdev.org/scapy-com/get/cc06add6dbd9.zip
+SCAPY=https://bitbucket.org/secdev/scapy-com/get/cc06add6dbd9.zip
 TMPFILE=`mktemp`
 wget $SCAPY -O $TMPFILE
 unzip $TMPFILE


### PR DESCRIPTION
http://bb.secdev.org/scapy-com/get/cc06add6dbd9.zip no longer exists(or my computer didn't fint it for some reason), changed it to https://bitbucket.org/secdev/scapy-com/get/cc06add6dbd9.zip
